### PR TITLE
Replace tags at config time instead of every write

### DIFF
--- a/kairosdb.conf
+++ b/kairosdb.conf
@@ -8,9 +8,13 @@
     Import "kairosdb_writer"
 
     <Module "kairosdb_writer">
+        #HostPostfix "myhost"
+        #HostSeparator "_"
         KairosDBHost "localhost"
         KairosDBPort 4242
         KairosDBProtocol "tcp"
+        #MetricPrefix "collectd"
+        #MetricSeparator "."
         LowercaseMetricNames true
         Tags "host=web01.company.local" "role=web01"
         TypesDB "/usr/share/collectd/types.db" "/etc/collectd/types/custom.db"

--- a/kairosdb_writer.py
+++ b/kairosdb_writer.py
@@ -208,12 +208,12 @@ def kairosdb_write(v, data=None):
     if len(v_type) != len(v.values):
         collectd.warning('kairosdb_writer: differing number of values for type %s' % v.type)
         return
-    
+
     metric_fields = []
     if prefix:
         metric_fields.append(prefix)
-    
-    if postfix is not None:
+
+    if postfix:
         metric_fields.append(postfix)
 
     metric_fields.append(v.plugin)

--- a/kairosdb_writer.py
+++ b/kairosdb_writer.py
@@ -244,7 +244,7 @@ def kairosdb_write(v, data=None):
 
         if new_value is not None:
             line = 'put %s %d %f %s' % ( metric, time, new_value, tags)
-            collectd.warning(line)
+            collectd.debug(line)
             lines.append(line)
 
         i += 1

--- a/kairosdb_writer.py
+++ b/kairosdb_writer.py
@@ -113,6 +113,8 @@ def kairosdb_config(c):
             for v in child.values:
                 tags += "%s " % (v)
 
+    tags = tags.replace('.', host_separator)
+
     if not host:
         raise Exception('KairosDBHost not defined')
 
@@ -206,9 +208,6 @@ def kairosdb_write(v, data=None):
     if len(v_type) != len(v.values):
         collectd.warning('kairosdb_writer: differing number of values for type %s' % v.type)
         return
-    
-    if tags:
-        tags = tags.replace('.', host_separator)
     
     metric_fields = []
     if prefix:


### PR DESCRIPTION
This fixes:
    UnboundLocalError: local variable 'tags' referenced before assignment

Python assumes that a variable is local as soon as you assign it
a new value.
