### PR TITLE
Convert plugin instance bits into tags!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 collectd-kairosdb
 ================
 
-A [KairosDB](https://code.google.com/p/kairosdb/) plugin for [collectd](http://collectd.org) using collectd's [Python plugin](http://collectd.org/documentation/manpages/collectd-python.5.shtml). 
+A [KairosDB](https://code.google.com/p/kairosdb/) plugin for [collectd](http://collectd.org) using collectd's [Python plugin](http://collectd.org/documentation/manpages/collectd-python.5.shtml).
 
 This is based on the [collectd-carbon](https://github.com/indygreg/collectd-carbon) plugin
 
@@ -30,7 +30,6 @@ Add the following to your collectd config **or** use the included kairosdb.conf.
             KairosDBProtocol "tcp"
             LowercaseMetricNames true
             TypesDB "/usr/share/collectd/types.db" "/etc/collectd/types/custom.db"
+            #Tags "host=foobar" "role=appserver"
         </Module>
     </Plugin>
-
-

--- a/kairosdb_writer.py
+++ b/kairosdb_writer.py
@@ -222,7 +222,7 @@ def kairosdb_write(v, data=None):
     if v.plugin_instance:
         # The "plugin instance" is used for plugins that collect the same
         # stats from multiple instances of a thing. For example: ethernet
-        # interfaces, cpus and disks. Since — for example — we want to be
+        # interfaces, cpus and disks. Since - for example - we want to be
         # able to easily sum total tx bytes we will make this a tag!
         instance_tags.append("instance=%s" % sanitize_field(v.plugin_instance))
 

--- a/kairosdb_writer.py
+++ b/kairosdb_writer.py
@@ -244,7 +244,7 @@ def kairosdb_write(v, data=None):
         path_fields = metric_fields[:]
         # Appending "value" onto the end of everything seems silly. Don't!
         if ds_name != "value":
-        path_fields.append(ds_name)
+            path_fields.append(ds_name)
 
         metric = '.'.join(path_fields)
 


### PR DESCRIPTION
- Moves plugin instance names to a tag called "instance" instead of in the metric name
- Eliminates the addition of "value" onto the end of metric names
- Documents the Tags option

If this isn't in line with your metric naming style, that's cool. I can maintain it as a fork.  Perhaps it could be a configuration option? 
